### PR TITLE
feat: Real SMS (Twilio) & Email (SendGrid) Notifications

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,12 @@
+# Twilio (SMS notifications)
+TWILIO_SID=your_account_sid
+TWILIO_AUTH_TOKEN=your_auth_token
+TWILIO_PHONE=+1234567890
+
+# SendGrid (email notifications)
+SENDGRID_API_KEY=your_sendgrid_api_key
+SENDGRID_FROM_EMAIL=noreply@tennispal.app
+
+# App secrets
+SECRET_KEY=change-me-in-production
+JWT_SECRET_KEY=change-me-in-production

--- a/api/notifications.py
+++ b/api/notifications.py
@@ -1,0 +1,91 @@
+"""
+Notification service for TennisPal.
+Sends real SMS (Twilio) and email (SendGrid) notifications.
+Falls back gracefully if credentials are not configured.
+"""
+import os
+import logging
+
+logger = logging.getLogger(__name__)
+
+# ── Twilio config ──
+TWILIO_SID = os.environ.get('TWILIO_SID')
+TWILIO_AUTH_TOKEN = os.environ.get('TWILIO_AUTH_TOKEN')
+TWILIO_PHONE = os.environ.get('TWILIO_PHONE')
+
+# ── SendGrid config ──
+SENDGRID_API_KEY = os.environ.get('SENDGRID_API_KEY')
+SENDGRID_FROM_EMAIL = os.environ.get('SENDGRID_FROM_EMAIL', 'noreply@tennispal.app')
+
+
+def _get_twilio_client():
+    if not all([TWILIO_SID, TWILIO_AUTH_TOKEN, TWILIO_PHONE]):
+        return None
+    try:
+        from twilio.rest import Client
+        return Client(TWILIO_SID, TWILIO_AUTH_TOKEN)
+    except Exception as e:
+        logger.warning(f"Twilio client init failed: {e}")
+        return None
+
+
+def send_sms(to_phone: str, body: str) -> bool:
+    """Send an SMS via Twilio. Returns True on success."""
+    if not to_phone:
+        return False
+    client = _get_twilio_client()
+    if not client:
+        logger.info(f"SMS skipped (no Twilio credentials): {to_phone}")
+        return False
+    try:
+        client.messages.create(body=body, from_=TWILIO_PHONE, to=to_phone)
+        logger.info(f"SMS sent to {to_phone}")
+        return True
+    except Exception as e:
+        logger.error(f"SMS failed to {to_phone}: {e}")
+        return False
+
+
+def send_email(to_email: str, subject: str, body: str) -> bool:
+    """Send an email via SendGrid. Returns True on success."""
+    if not to_email or not SENDGRID_API_KEY:
+        if not SENDGRID_API_KEY:
+            logger.info(f"Email skipped (no SendGrid credentials): {to_email}")
+        return False
+    try:
+        from sendgrid import SendGridAPIClient
+        from sendgrid.helpers.mail import Mail
+        message = Mail(
+            from_email=SENDGRID_FROM_EMAIL,
+            to_emails=to_email,
+            subject=subject,
+            html_content=f"""
+            <div style="font-family: sans-serif; max-width: 500px; margin: 0 auto;">
+                <div style="background: #16a34a; color: white; padding: 16px 24px; border-radius: 8px 8px 0 0;">
+                    <h2 style="margin: 0;">🎾 TennisPal</h2>
+                </div>
+                <div style="padding: 24px; background: #f9fafb; border-radius: 0 0 8px 8px;">
+                    <p>{body}</p>
+                </div>
+            </div>
+            """,
+        )
+        sg = SendGridAPIClient(SENDGRID_API_KEY)
+        sg.send(message)
+        logger.info(f"Email sent to {to_email}")
+        return True
+    except Exception as e:
+        logger.error(f"Email failed to {to_email}: {e}")
+        return False
+
+
+def notify_user(user, message: str, subject: str = "TennisPal Notification"):
+    """
+    Send notification to a user based on their preferences.
+    Always creates an in-app notification (caller handles that).
+    This sends the external SMS/email if the user opted in.
+    """
+    if user.notify_sms and user.phone:
+        send_sms(user.phone, message)
+    if user.notify_email and user.email:
+        send_email(user.email, subject, message)

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -14,6 +14,7 @@ import Leaderboard from './pages/Leaderboard';
 import AvailabilityPage from './pages/AvailabilityPage';
 import Notifications from './pages/Notifications';
 import Profile from './pages/Profile';
+import Settings from './pages/Settings';
 
 function AppRoutes() {
   const { user, loading } = useAuth();
@@ -44,6 +45,7 @@ function AppRoutes() {
           <Route path="/availability" element={<AvailabilityPage />} />
           <Route path="/notifications" element={<Notifications />} />
           <Route path="/profile" element={<Profile />} />
+          <Route path="/settings" element={<Settings />} />
           <Route path="*" element={<Navigate to="/" />} />
         </Routes>
       </div>

--- a/frontend/src/pages/Profile.tsx
+++ b/frontend/src/pages/Profile.tsx
@@ -17,6 +17,7 @@ export default function Profile() {
       </div>
       <Link to={`/players/${user.id}`} className="block bg-white rounded-xl shadow p-4 text-center text-green-700 font-semibold hover:bg-green-50">View Full Profile</Link>
       <Link to="/availability" className="block bg-white rounded-xl shadow p-4 text-center text-green-700 font-semibold hover:bg-green-50">📅 Manage Availability</Link>
+      <Link to="/settings" className="block bg-white rounded-xl shadow p-4 text-center text-green-700 font-semibold hover:bg-green-50">🔔 Notification Settings</Link>
       <Link to="/leaderboard" className="block bg-white rounded-xl shadow p-4 text-center text-green-700 font-semibold hover:bg-green-50">🏆 Leaderboard</Link>
       <button onClick={logout} className="w-full bg-red-100 text-red-600 rounded-xl p-4 font-semibold">Log Out</button>
     </div>

--- a/frontend/src/pages/Settings.tsx
+++ b/frontend/src/pages/Settings.tsx
@@ -1,0 +1,77 @@
+import { useState, useEffect } from 'react';
+import { useAuth } from '../context/AuthContext';
+
+export default function Settings() {
+  const { token } = useAuth();
+  const [notifySms, setNotifySms] = useState(false);
+  const [notifyEmail, setNotifyEmail] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [loaded, setLoaded] = useState(false);
+
+  useEffect(() => {
+    fetch('/api/settings', { headers: { Authorization: `Bearer ${token}` } })
+      .then(r => r.json())
+      .then(d => {
+        setNotifySms(d.settings.notify_sms);
+        setNotifyEmail(d.settings.notify_email);
+        setLoaded(true);
+      });
+  }, [token]);
+
+  const save = async (sms: boolean, email: boolean) => {
+    setSaving(true);
+    await fetch('/api/settings', {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
+      body: JSON.stringify({ notify_sms: sms, notify_email: email }),
+    });
+    setSaving(false);
+  };
+
+  const toggleSms = () => {
+    const v = !notifySms;
+    setNotifySms(v);
+    save(v, notifyEmail);
+  };
+
+  const toggleEmail = () => {
+    const v = !notifyEmail;
+    setNotifyEmail(v);
+    save(notifySms, v);
+  };
+
+  if (!loaded) return <div className="p-4 text-center text-gray-400">Loading...</div>;
+
+  return (
+    <div className="p-4 pb-24 max-w-lg mx-auto space-y-4">
+      <h1 className="text-2xl font-bold text-green-700">Notification Settings</h1>
+      <div className="bg-white rounded-xl shadow divide-y">
+        <label className="flex items-center justify-between p-4 cursor-pointer">
+          <div>
+            <div className="font-medium">📧 Email Notifications</div>
+            <div className="text-sm text-gray-500">Match invites, score updates, etc.</div>
+          </div>
+          <div
+            onClick={toggleEmail}
+            className={`w-12 h-7 rounded-full relative transition-colors ${notifyEmail ? 'bg-green-500' : 'bg-gray-300'}`}
+          >
+            <div className={`absolute top-0.5 w-6 h-6 bg-white rounded-full shadow transition-transform ${notifyEmail ? 'translate-x-5' : 'translate-x-0.5'}`} />
+          </div>
+        </label>
+        <label className="flex items-center justify-between p-4 cursor-pointer">
+          <div>
+            <div className="font-medium">📱 SMS Notifications</div>
+            <div className="text-sm text-gray-500">Text messages to your phone number</div>
+          </div>
+          <div
+            onClick={toggleSms}
+            className={`w-12 h-7 rounded-full relative transition-colors ${notifySms ? 'bg-green-500' : 'bg-gray-300'}`}
+          >
+            <div className={`absolute top-0.5 w-6 h-6 bg-white rounded-full shadow transition-transform ${notifySms ? 'translate-x-5' : 'translate-x-0.5'}`} />
+          </div>
+        </label>
+      </div>
+      {saving && <div className="text-center text-sm text-gray-400">Saving...</div>}
+    </div>
+  );
+}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,9 @@
 Flask==3.0.0
 Flask-SQLAlchemy==3.1.1
 Flask-Login==0.6.3
+Flask-CORS==4.0.0
+Flask-JWT-Extended==4.6.0
 Werkzeug==3.0.1
 Faker==22.0.0
+twilio>=8.0.0
+sendgrid>=6.10.0


### PR DESCRIPTION
## What
Implements real SMS and email notifications, replacing the in-app-only notification system.

## Changes
- **`api/notifications.py`** — New notification service with Twilio SMS and SendGrid email integration. Gracefully falls back (logs + skips) when credentials aren't configured.
- **`api/app.py`** — All 5 notification points now call `notify_user()` for external delivery (post claims, invites sent/accepted/declined, score submissions). Added `GET/PUT /api/settings` endpoints for notification preferences.
- **`frontend/src/pages/Settings.tsx`** — New settings page with toggle switches for email and SMS notifications.
- **`frontend/src/pages/Profile.tsx`** — Added link to notification settings.
- **`frontend/src/App.tsx`** — Added /settings route.
- **`requirements.txt`** — Added `twilio>=8.0.0` and `sendgrid>=6.10.0`.
- **`.env.example`** — Documents all required environment variables.

## Configuration
Set these env vars to enable external notifications:
```
TWILIO_SID, TWILIO_AUTH_TOKEN, TWILIO_PHONE  # SMS
SENDGRID_API_KEY, SENDGRID_FROM_EMAIL        # Email
```
Without them, the app works normally — notifications stay in-app only.

## User model
Already has `notify_sms` (default False) and `notify_email` (default True) fields — no migration needed.