### PR TITLE
feat: Email Verification Flow

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -1,0 +1,680 @@
+# TennisPal — Application Specification
+
+> **Version:** 1.0 · **Date:** 2026-03-01 · **Author:** Auto-generated from source code
+
+---
+
+## Table of Contents
+
+1. [Overview & Tech Stack](#1-overview--tech-stack)
+2. [User Roles & Permissions](#2-user-roles--permissions)
+3. [Authentication](#3-authentication)
+4. [Onboarding Flow](#4-onboarding-flow)
+5. [Feed / Looking to Play](#5-feed--looking-to-play)
+6. [Match Invites](#6-match-invites)
+7. [Match Lifecycle](#7-match-lifecycle)
+8. [Score Submission & Validation](#8-score-submission--validation)
+9. [Elo Rating System](#9-elo-rating-system)
+10. [Player Profiles](#10-player-profiles)
+11. [Leaderboard](#11-leaderboard)
+12. [Availability System](#12-availability-system)
+13. [Courts](#13-courts)
+14. [Notifications](#14-notifications)
+15. [Post-Match Reviews](#15-post-match-reviews)
+16. [Matchmaking Suggestions](#16-matchmaking-suggestions)
+17. [Settings](#17-settings)
+18. [Admin Dashboard](#18-admin-dashboard)
+19. [Known Limitations / TODO](#19-known-limitations--todo)
+
+---
+
+## 1. Overview & Tech Stack
+
+**TennisPal** is a mobile-first web app for recreational tennis players to find opponents, schedule matches, track scores, and build a local tennis community.
+
+### Tech Stack
+| Layer | Technology |
+|-------|-----------|
+| **Backend** | Python / Flask, Flask-JWT-Extended, Flask-SQLAlchemy, Flask-CORS |
+| **Database** | SQLite (file: `tennispal.db`) |
+| **Frontend** | React 18 + TypeScript, Vite, TailwindCSS, React Query, React Router v6 |
+| **Auth** | JWT (30-day expiry), bcrypt password hashing (werkzeug) |
+| **Notifications** | In-app + optional Twilio SMS + SendGrid email |
+| **Deployment** | Gunicorn on Debian VPS (72.61.12.118), nginx reverse proxy, systemd |
+
+### Architecture
+- SPA frontend served from `/frontend/dist` in release mode
+- All API routes prefixed with `/api/`
+- JWT token passed as `Authorization: Bearer <token>` header
+- City-scoped data (currently Pittsburgh-focused)
+
+---
+
+## 2. User Roles & Permissions
+
+### Regular User
+- Register, login, complete onboarding
+- Create/edit/delete own "Looking to Play" posts
+- Send and receive match invites
+- Submit and confirm scores
+- View leaderboard, players, courts
+- Manage own profile, availability, and notification settings
+- Submit post-match reviews
+
+### Admin
+- All regular user permissions
+- Access admin dashboard via separate login (`/api/admin/login`)
+- View platform stats (users, matches, posts, notifications)
+- Search/paginate users; edit user fields (name, email, NTRP, Elo, is_admin, is_banned)
+- Ban/unban users
+- View/filter/edit/delete matches
+- Send broadcast or targeted notifications
+- Auth: `X-Admin-Token` header with valid JWT of an `is_admin=True` user
+
+### Banned User
+- Cannot log in (receives "Your account has been suspended." 403 error)
+
+### Acceptance Criteria
+- [ ] Non-admin user cannot access `/api/admin/*` endpoints
+- [ ] Banned user receives 403 on login attempt
+- [ ] Admin token is validated on every admin endpoint
+
+---
+
+## 3. Authentication
+
+### Register (`POST /api/auth/register`)
+**Fields:** name (required), email or phone (at least one required), password (required), ntrp (optional, 1.0–7.0), city (default: "Pittsburgh")
+
+**Business Rules:**
+- Name and password are required; must provide email or phone
+- Email must be unique; phone must be unique
+- NTRP validated: must be float between 1.0 and 7.0
+- Returns JWT token + user object; status 201
+- New user starts with `elo=1200`, `onboarding_complete=False`
+
+**Acceptance Criteria:**
+- [ ] `POST /api/auth/register` with valid data → 201, returns `{token, user}`
+- [ ] Missing name or password → 400
+- [ ] No email and no phone → 400
+- [ ] Duplicate email → 409 "Email already registered."
+- [ ] Duplicate phone → 409 "Phone already registered."
+- [ ] NTRP=8.0 → 400 "NTRP must be between 1.0 and 7.0."
+
+### Login (`POST /api/auth/login`)
+**Fields:** identifier (email or phone), password
+
+**Business Rules:**
+- Matches against both `email` and `phone` columns
+- Banned users get 403
+- Returns JWT token + user object on success
+
+**Acceptance Criteria:**
+- [ ] Valid credentials → 200, returns `{token, user}`
+- [ ] Wrong password → 401 "Invalid credentials."
+- [ ] Banned user → 403 "Your account has been suspended."
+
+### Current User (`GET /api/auth/me`)
+- Requires JWT; returns full user dict
+
+---
+
+## 4. Onboarding Flow
+
+After registration, users must complete onboarding before accessing the main app. The frontend forces all routes to `<Onboarding />` until `onboarding_complete=True`.
+
+### Steps (Frontend)
+1. **Welcome** — greeting screen
+2. **NTRP Selection** — pick skill level from predefined options:
+   - 2.0: "Beginner — Learning basic strokes"
+   - 2.5: "Beginner+ — Can sustain a short rally"
+   - 3.0: "Intermediate — Consistent on medium-paced shots"
+   - 3.5: "Intermediate+ — Improved consistency, developing variety"
+   - 4.0: "Advanced Intermediate — Dependable strokes, directional control"
+   - 4.5: "Advanced — Can use power and spin effectively"
+   - 5.0: "Advanced+ — Strong shot anticipation, can vary game plan"
+   - 5.5: "Expert — Can hit winners, tournament-level play"
+3. **Contact Info** — name, email, phone
+4. **Preferred Courts** — GPS-based nearby court selection (requests browser geolocation, 25km radius), searchable list, multi-select
+
+### API (`PUT /api/onboarding`)
+- Accepts: ntrp, name, phone, email, preferred_courts (array)
+- Sets `onboarding_complete = True`
+- Validates uniqueness of email/phone
+- preferred_courts stored as JSON string
+
+**Acceptance Criteria:**
+- [ ] User with `onboarding_complete=False` is redirected to onboarding on all routes
+- [ ] Completing onboarding sets flag to True; user can now access main app
+- [ ] Duplicate phone during onboarding → 409
+- [ ] GPS-based court list appears when geolocation is granted
+
+---
+
+## 5. Feed / Looking to Play
+
+The home page shows a feed of "Looking to Play" posts — open requests from players seeking opponents.
+
+### Data Model: `LookingToPlay`
+| Field | Type | Notes |
+|-------|------|-------|
+| user_id | FK→User | Post author |
+| play_date | Date | Must be today or future |
+| start_time | String(5) | "HH:MM" format |
+| end_time | String(5) | "HH:MM" format |
+| court | String(100) | Default: "Flexible" |
+| match_type | String(20) | Default: "singles" |
+| level_min | Float | Optional NTRP floor |
+| level_max | Float | Optional NTRP ceiling |
+| claimed_by_id | FK→User | Set when post is claimed via accepted invite |
+
+### Computed Properties
+- `is_expired`: True if current time > `play_date + end_time`
+- `is_active`: Not expired AND not claimed
+
+### List Posts (`GET /api/posts`)
+**Filters (query params):**
+- `level_min`, `level_max` — NTRP range filter
+- `court` — case-insensitive substring match
+- `date_from`, `date_to` — date range (YYYY-MM-DD)
+
+**Sorting (`sort` param):**
+- `newest` (default) — by created_at desc
+- `closest_date` — by play_date asc, then start_time
+- `skill_match` — by distance between user's NTRP and post's level midpoint
+
+**Personalization (`for_you=true`):**
+- Scores each post based on NTRP fit (max 10pts for perfect range match) and court preference match (5pts)
+- Sorts by score desc, then play_date
+
+**Business Rules:**
+- Only shows unclaimed posts with `play_date >= today`
+- Filters out expired posts (past end_time)
+- No auth required to view; auth needed for personalization features
+
+### Create Post (`POST /api/posts`)
+- Auth required
+- Required: play_date, start_time, end_time
+- play_date must be today or future
+- Returns 201
+
+### Edit Post (`PUT /api/posts/<id>`)
+- Auth required; must be post owner
+- Cannot edit if post is claimed
+- Same validations as create
+
+### Delete Post (`DELETE /api/posts/<id>`)
+- Auth required; must be post owner
+- Cannot delete if claimed
+
+### Claim/Request Post (`POST /api/posts/<id>/claim`)
+- Creates a `MatchInvite` (pending) to the post owner
+- Cannot claim own post
+- Cannot claim inactive post
+- Prevents duplicate pending requests (same user + same post) → 409
+- Creates notification for post owner
+- Sends external notification (SMS/email) to post owner
+
+**Acceptance Criteria:**
+- [ ] Active posts visible on feed without login
+- [ ] Expired posts (past end_time) hidden from feed
+- [ ] Claimed posts hidden from feed
+- [ ] Filter by NTRP range returns matching posts
+- [ ] `sort=closest_date` orders by soonest first
+- [ ] Post owner cannot claim own post → 400
+- [ ] Duplicate claim → 409
+- [ ] Claimed post cannot be edited or deleted → 400
+
+---
+
+## 6. Match Invites
+
+Two paths create invites:
+1. **Direct invite** (`POST /api/invites`) — player invites another player directly
+2. **Post claim** (`POST /api/posts/<id>/claim`) — player requests to play from a feed post
+
+### Data Model: `MatchInvite`
+| Field | Type | Notes |
+|-------|------|-------|
+| from_user_id | FK→User | Sender |
+| to_user_id | FK→User | Recipient |
+| post_id | FK→LookingToPlay | Null for direct invites |
+| play_date | Date | |
+| start_time, end_time | String(5) | |
+| court | String(100) | Default: "TBD" |
+| match_type | String(20) | Default: "singles" |
+| status | String(20) | `pending`, `accepted`, `declined` |
+
+### Send Direct Invite (`POST /api/invites`)
+- Cannot invite yourself → 400
+- Creates notification + external notification to recipient
+
+### Accept Invite (`POST /api/invites/<id>/accept`)
+- Only the `to_user` can accept
+- Must be `pending` status
+- Creates a `Match` record (status: `scheduled`)
+- If from a post: claims the post (`claimed_by_id = from_user_id`) and auto-declines all other pending requests for that post
+- Notifies the invite sender
+
+### Decline Invite (`POST /api/invites/<id>/decline`)
+- Only the `to_user` can decline
+- Must be `pending` status
+- Notifies the invite sender
+
+### View Invites (`GET /api/matches`)
+- Returns: user's matches + `pending_invites` (received) + `sent_invites` (sent)
+
+**Acceptance Criteria:**
+- [ ] Accepting a post-based invite claims the post
+- [ ] Other pending requests for the same post are auto-declined with notification
+- [ ] Self-invite → 400
+- [ ] Accepting already-accepted invite → 400
+- [ ] Only recipient can accept/decline
+
+---
+
+## 7. Match Lifecycle
+
+### States
+```
+scheduled → completed (score submitted) → confirmed (opponent confirms)
+                                        → disputed (opponent disputes)
+scheduled → cancelled
+```
+
+### Data Model: `Match`
+| Field | Type | Notes |
+|-------|------|-------|
+| player1_id, player2_id | FK→User | |
+| play_date | Date | |
+| match_type | String(20) | "singles" |
+| match_format | String(30) | "best_of_3", "pro_set", "best_of_5" |
+| status | String(20) | "scheduled", "completed", "cancelled" |
+| score | String(100) | Human-readable: "6-4, 6-3" |
+| sets | Text (JSON) | Structured: `[{"p1":6,"p2":4},...]` |
+| score_submitted_by | FK→User | |
+| score_confirmed | Boolean | |
+| score_disputed | Boolean | |
+| winner_id | FK→User | |
+
+### Upcoming Matches (`GET /api/matches/upcoming`)
+- Returns scheduled matches with `play_date >= today`, sorted ascending
+- Includes opponent details (name, NTRP)
+
+### Recent Results (`GET /api/matches/recent`)
+- Returns confirmed matches, sorted by play_date desc
+- Default limit: 30
+
+### Match Detail (`GET /api/matches/<id>`)
+- Returns match data
+- If participant + completed + confirmed: includes opponent contact info (email, phone)
+
+### Cancel Match (`POST /api/matches/<id>/cancel`)
+- Only participants can cancel
+- Sets status to "cancelled"
+
+**Acceptance Criteria:**
+- [ ] Scheduled match appears in upcoming matches
+- [ ] Cancelled match no longer appears as upcoming
+- [ ] Opponent contact info only visible after score confirmation
+
+---
+
+## 8. Score Submission & Validation
+
+### Submit Score (`POST /api/matches/<id>/score`)
+- Only match participants can submit
+- Cannot resubmit after confirmation
+
+#### Structured Score (preferred)
+Payload: `{ sets: [...], match_format: "best_of_3" }`
+
+**Validation rules:**
+- **best_of_3**: 2–3 sets required; first to win 2 sets
+- **best_of_5**: 3–5 sets required; first to win 3 sets
+- **pro_set**: exactly 1 set; at least one player reaches 8 games
+
+**Per-set validation:**
+- Scores must be integers 0–7
+- At least one player must reach 6 games (normal set)
+- 7 games only valid vs 5 or 6 opponent games
+- 7-6 requires tiebreak scores: `{p1: int, p2: int}`
+- Tiebreak winner must reach ≥7 and win by ≥2
+- Tiebreak winner must match set winner
+- No ties allowed in a set
+- Match must end when deciding set is won (no extra sets)
+
+**Winner auto-determined** from set scores.
+
+#### Legacy Free-Text Score
+Payload: `{ score: "6-4, 6-3", winner_id: <id> }`
+- Score validated via regex: only digits, dashes, parentheses, commas, spaces
+- Max 100 chars
+- winner_id must be a match participant
+
+### Confirm/Dispute Score (`POST /api/matches/<id>/confirm`)
+- Only the non-submitter can confirm
+- `action: "confirm"` → sets `score_confirmed = True`
+- `action: "dispute"` → sets `score_disputed = True`
+- Submitter cannot confirm own score → 400
+
+**Acceptance Criteria:**
+- [ ] Structured score `6-4, 6-3` in best_of_3 → accepted, winner auto-set
+- [ ] `7-6` without tiebreak → 400
+- [ ] 3 sets where first 2 are won by same player → 400 "Too many sets"
+- [ ] Submitter tries to confirm own score → 400
+- [ ] Already confirmed score cannot be resubmitted → 400
+- [ ] Tiebreak `7-6(3)` with wrong winner side → 400
+
+---
+
+## 9. Elo Rating System
+
+### Current State
+- Default Elo: **1200** for new users
+- Elo is stored on the `User` model as an integer
+- **Elo is NOT automatically updated** after match confirmation (no calculation logic in code)
+- Admins can manually set Elo via admin panel
+- Leaderboard sorts by Elo descending
+
+### Matchmaking Usage
+- Elo proximity used in matchmaking scoring (max 30pts for close Elo)
+- Elo difference ≤100 triggers "Similar Elo" reason
+
+**Known Limitation:** Elo updates are not implemented. This is a TODO item.
+
+---
+
+## 10. Player Profiles
+
+### View Own Profile (`GET /api/auth/me`)
+- Full user data including stats
+
+### View Other Player (`GET /api/players/<id>`)
+- Full user data + match history (all matches, sorted by date desc)
+
+### Edit Profile (`PUT /api/profile`)
+Editable fields: name, phone, email, ntrp, city, preferred_courts
+
+**Validation:**
+- Name cannot be empty
+- NTRP: must be valid 0.5 increment between 1.0–7.0 (valid values: 1.0, 1.5, 2.0, ..., 7.0)
+- Email: regex validated, must be unique
+- Phone: must be unique
+
+### Computed Stats (on User model)
+| Stat | Calculation |
+|------|------------|
+| wins | Count of confirmed matches where user is winner |
+| losses | Count of confirmed matches where user is not winner |
+| matches_played | Count of confirmed matches user participated in |
+| unique_opponents | Count of distinct opponents in confirmed matches |
+| reliability | `completed / (completed + cancelled + no_show) * 100` (100% if no data) |
+
+### Head-to-Head (`GET /api/players/<id>/h2h`)
+- Auth required
+- Returns wins, losses, and match list between current user and target player
+- Returns null if viewing own profile
+
+### Profile Tags (`GET /api/users/<id>/tags`)
+- Aggregates review tags from all reviews of this player
+- **Public tags**: only tags with ≥2 endorsements
+- **All tags**: complete list with counts
+
+**Acceptance Criteria:**
+- [ ] NTRP 3.7 → 400 "must be a valid level (1.0–7.0 in 0.5 increments)"
+- [ ] Empty name → 400
+- [ ] Duplicate email on different user → 409
+- [ ] H2H returns correct win/loss counts between two players
+- [ ] Profile tags with <2 endorsements hidden from public view
+
+---
+
+## 11. Leaderboard
+
+### Endpoint (`GET /api/leaderboard`)
+- **No auth required**
+- Returns all users sorted by: Elo desc, then wins desc
+- Fields: id, name, ntrp, elo, wins, losses, matches_played
+
+**Acceptance Criteria:**
+- [ ] Players sorted by Elo descending
+- [ ] Tied Elo → higher wins first
+- [ ] Accessible without login
+
+---
+
+## 12. Availability System
+
+Weekly recurring time slots indicating when a player is free to play.
+
+### Data Model: `Availability`
+| Field | Type | Notes |
+|-------|------|-------|
+| user_id | FK→User | |
+| day_of_week | Integer | 0=Monday, 6=Sunday |
+| start_time | String(5) | "HH:MM" |
+| end_time | String(5) | "HH:MM" |
+
+### Endpoints
+- `GET /api/availability` — list current user's slots
+- `POST /api/availability` — add slot (day_of_week 0-6, start_time, end_time required)
+- `DELETE /api/availability/<id>` — remove slot (only own slots)
+
+### Usage
+- Players page can filter by available day
+- Matchmaking uses availability overlap for scoring
+
+**Acceptance Criteria:**
+- [ ] day_of_week=-1 → 400
+- [ ] day_of_week=7 → 400
+- [ ] Missing start_time → 400
+- [ ] Cannot delete another user's slot → 403
+
+---
+
+## 13. Courts
+
+### Data Model: `Court`
+| Field | Type | Notes |
+|-------|------|-------|
+| name | String(200) | |
+| address | String(300) | |
+| lat, lng | Float | GPS coordinates |
+| num_courts | Integer | Default: 1 |
+| lighted | Boolean | Default: False |
+| surface | String(50) | Default: "hard" |
+| public | Boolean | Default: True |
+
+### Endpoints
+- `GET /api/courts` — list all courts; if `lat`+`lng` provided, includes `distance_km` and sorts by distance; optional `radius` filter
+- `GET /api/courts/<id>` — single court
+- `GET /api/courts/nearby` — requires `lat`+`lng`; default radius 5km
+
+### Distance Calculation
+- Haversine formula (great-circle distance in km)
+
+### Seed Data
+15 Pittsburgh-area courts pre-loaded (Arsenal Park, Schenley Park, Mellon Park, Highland Park, Frick Park, CMU, etc.)
+
+**Acceptance Criteria:**
+- [ ] `/api/courts/nearby` without lat/lng → 400
+- [ ] Courts sorted by distance when coordinates provided
+- [ ] Radius filter excludes far courts
+
+---
+
+## 14. Notifications
+
+### Data Model: `Notification`
+| Field | Type |
+|-------|------|
+| user_id | FK→User |
+| message | String(500) |
+| read | Boolean (default False) |
+| created_at | DateTime |
+| link | String(200), nullable |
+
+### Endpoints
+- `GET /api/notifications` — last 50, sorted by newest first
+- `GET /api/notifications/unread-count` — integer count
+- `POST /api/notifications/mark-read` — mark specific IDs or all as read
+
+### Notification Triggers
+| Event | Recipient | Message |
+|-------|-----------|---------|
+| Post claim (request) | Post owner | "{name} wants to play on {date}! Review and accept/decline." |
+| Direct invite | Invitee | "{name} invited you to play on {date}!" |
+| Invite accepted | Sender | "{name} accepted your request/invite for {date}!" |
+| Invite declined | Sender | "{name} declined your request/invite." |
+| Post request auto-declined | Requester | "Your request to play on {date} was declined — the poster chose another player." |
+| Score submitted | Opponent | "{name} submitted a score: {score}. Please confirm." |
+| Admin broadcast | Target users | Custom message |
+
+### External Notifications
+- **SMS** (Twilio): sent if `user.notify_sms=True` and phone exists and Twilio credentials configured
+- **Email** (SendGrid): sent if `user.notify_email=True` and email exists and SendGrid credentials configured
+- Graceful fallback: logs and continues if credentials missing
+
+**Acceptance Criteria:**
+- [ ] Unread count reflects actual unread notifications
+- [ ] Mark-read with specific IDs only marks those
+- [ ] Mark-read without IDs marks ALL as read
+- [ ] Notification created on every trigger event listed above
+
+---
+
+## 15. Post-Match Reviews
+
+Tag-based review system (no free-text, no star ratings).
+
+### Data Model: `ReviewTag`
+| Field | Type | Notes |
+|-------|------|-------|
+| name | String(50) | Unique |
+| category | String(30) | play_style, sportsmanship, logistics, vibe |
+
+### Seed Tags
+- **play_style:** Big Server, Consistent Baseliner, Net Rusher, Heavy Topspin, Crafty, All-Court Player
+- **sportsmanship:** Great Sport, Fair Calls, Encouraging, Competitive
+- **logistics:** Punctual, Flexible Scheduling, Good Communication
+- **vibe:** Fun Rally Partner, Intense Competitor, Great for Practice
+
+### Data Model: `PlayerReview`
+- reviewer_id, reviewee_id, match_id, tags (many-to-many)
+- Unique constraint: one review per reviewer per match
+
+### Submit Review (`POST /api/matches/<id>/review`)
+- Auth required; must be match participant
+- Match score must be confirmed first
+- Must select at least 1 tag
+- Cannot review same match twice → 409
+- Reviewee is automatically the other participant
+
+### Review Status (`GET /api/matches/<id>/review-status`)
+- Returns whether current user has reviewed this match
+
+### Available Tags (`GET /api/review-tags`)
+- Returns tags grouped by category
+
+**Acceptance Criteria:**
+- [ ] Cannot review before score confirmation → 400
+- [ ] Duplicate review → 409
+- [ ] Zero tags selected → 400
+- [ ] Invalid tag ID → 400
+- [ ] Tags with ≥2 endorsements appear in player's public profile
+
+---
+
+## 16. Matchmaking Suggestions
+
+### Endpoint (`GET /api/matchmaking/suggestions`)
+Auth required. Returns all other users ranked by composite "match score".
+
+### Scoring Algorithm (max 100 points)
+
+| Factor | Max Points | Calculation |
+|--------|-----------|-------------|
+| Elo Proximity | 30 | `max(0, 30 - elo_diff/10)` |
+| NTRP Similarity | 20 | `max(0, 20 - ntrp_diff*10)` |
+| Availability Overlap | 25 | `min(25, overlap_minutes/60 * 5)` |
+| Variety (new opponents) | 15 | `max(0, 15 - recent_matches*5)` |
+| Reliability | 10 | `reliability/100 * 10` |
+
+### Reasons Returned
+- "Similar Elo" — Elo diff ≤100
+- "Similar NTRP level" — NTRP diff ≤0.5
+- "Overlapping schedule" — any availability overlap
+- "New opponent" — 0 recent matches (last 30 days)
+- "Highly reliable" — reliability ≥90%
+
+### Response Fields
+id, name, ntrp, elo, match_score, reasons, elo_diff, recent_matches, availability_overlap, reliability
+
+**Acceptance Criteria:**
+- [ ] User with identical Elo/NTRP/availability scores highest
+- [ ] Player with 3 recent matches against user gets reduced variety score
+- [ ] Suggestions sorted by match_score descending
+
+---
+
+## 17. Settings
+
+### Notification Preferences
+- `GET /api/settings` — returns `{notify_sms, notify_email}`
+- `PUT /api/settings` — toggle SMS and/or email notifications
+
+**Acceptance Criteria:**
+- [ ] Toggle notify_email off → no email sent on next notification trigger
+- [ ] Toggle notify_sms on → SMS sent if phone number and Twilio credentials exist
+
+---
+
+## 18. Admin Dashboard
+
+### Authentication
+- Login: `POST /api/admin/login` — must be `is_admin=True` user
+- All admin endpoints require `X-Admin-Token` header with valid admin JWT
+
+### Endpoints
+
+| Endpoint | Method | Description |
+|----------|--------|-------------|
+| `/api/admin/stats` | GET | Platform overview stats |
+| `/api/admin/users` | GET | Paginated user list with search |
+| `/api/admin/users/<id>` | PUT | Edit user fields |
+| `/api/admin/users/<id>/ban` | POST | Ban user |
+| `/api/admin/users/<id>/unban` | POST | Unban user |
+| `/api/admin/matches` | GET | Paginated match list with status filter |
+| `/api/admin/matches/<id>` | PUT | Edit match (status, confirmed, disputed) |
+| `/api/admin/matches/<id>` | DELETE | Delete match |
+| `/api/admin/notifications` | POST | Send notification to specific users or broadcast |
+
+### Stats Returned
+total_users, banned_users, total_matches, completed_matches, scheduled_matches, disputed_matches, active_posts, pending_invites, total_notifications, unread_notifications, new_users_week, new_users_month
+
+**Acceptance Criteria:**
+- [ ] Non-admin JWT → 403 on admin endpoints
+- [ ] Missing X-Admin-Token → 401
+- [ ] Ban user → user cannot login
+- [ ] Broadcast notification reaches all non-banned users
+
+---
+
+## 19. Known Limitations / TODO
+
+1. **Elo not auto-updated** — Elo rating stored but never recalculated after matches. Need K-factor-based update on score confirmation.
+2. **No password reset** — No forgot-password or reset flow.
+3. **No image upload** — No profile pictures or court photos.
+4. **SQLite** — Single-file DB; not suitable for high concurrency. Migration to PostgreSQL recommended for production.
+5. **No real-time updates** — Polling-based; no WebSocket/SSE for live notifications.
+6. **No email verification** — Emails accepted without confirmation.
+7. **City is cosmetic** — City field exists but doesn't filter data (all users see all data).
+8. **No doubles support** — match_type field exists but UI and logic are singles-only.
+9. **No match time storage** — Matches track play_date but not specific time.
+10. **No dispute resolution** — Disputed scores have no workflow; admin must intervene manually.
+11. **Reliability stat counts no_show** — but no_show status is never set by any endpoint.
+12. **Tiebreak display** — Shows minimum tiebreak score in parentheses (e.g., "7-6(5)") rather than winner's score.
+13. **No rate limiting** — API has no request throttling.
+14. **preferred_courts inconsistency** — Stored as JSON array via onboarding but as raw text via profile edit. Profile edit sends string; comparison logic splits on commas.
+15. **No pagination on feed** — All active posts loaded at once.

--- a/api/app.py
+++ b/api/app.py
@@ -4,6 +4,10 @@ from flask_jwt_extended import JWTManager, create_access_token, jwt_required, ge
 from werkzeug.security import generate_password_hash, check_password_hash
 from models import db, User, Availability, LookingToPlay, MatchInvite, Match, Notification, Court, ReviewTag, PlayerReview
 from notifications import notify_user
+from email_verification import (
+    generate_verification_token, send_verification_email,
+    check_rate_limit, record_send, is_token_expired, email_verified_required,
+)
 from datetime import datetime, date, timedelta
 import os
 import json
@@ -61,10 +65,28 @@ def register():
     city = data.get('city', 'Pittsburgh')
     user = User(name=name, email=email, phone=phone,
                 password_hash=generate_password_hash(password), ntrp=ntrp, city=city)
+
+    # Email verification setup
+    if email:
+        v_token = generate_verification_token()
+        user.verification_token = v_token
+        user.verification_sent_at = datetime.utcnow()
+        user.email_verified = False
+    else:
+        # No email provided — treat as verified (phone-only users)
+        user.email_verified = True
+
     db.session.add(user)
     db.session.commit()
+
+    # Send verification email (after commit so user exists)
+    if email:
+        ip = request.remote_addr or '0.0.0.0'
+        record_send(ip, email)
+        send_verification_email(email, v_token)
+
     token = create_access_token(identity=str(user.id))
-    return jsonify(token=token, user=user.to_dict()), 201
+    return jsonify(token=token, user=user.to_dict(), email_verification_sent=bool(email)), 201
 
 
 @app.route('/api/auth/login', methods=['POST'])
@@ -88,6 +110,49 @@ def me():
     if not user:
         return jsonify(error='User not found.'), 404
     return jsonify(user=user.to_dict())
+
+
+@app.route('/api/auth/verify-email', methods=['POST'])
+def verify_email():
+    data = request.get_json() or {}
+    token = data.get('token', '').strip()
+    if not token:
+        return jsonify(error='Token is required.'), 400
+    user = User.query.filter_by(verification_token=token).first()
+    if not user:
+        return jsonify(error='Invalid or expired verification token.'), 400
+    if user.email_verified:
+        return jsonify(message='Email already verified.', user=user.to_dict())
+    if is_token_expired(user.verification_sent_at):
+        return jsonify(error='Verification token has expired. Please request a new one.'), 400
+    user.email_verified = True
+    user.verification_token = None
+    db.session.commit()
+    return jsonify(message='Email verified successfully!', user=user.to_dict())
+
+
+@app.route('/api/auth/resend-verification', methods=['POST'])
+@jwt_required()
+def resend_verification():
+    uid = int(get_jwt_identity())
+    user = User.query.get(uid)
+    if not user:
+        return jsonify(error='User not found.'), 404
+    if user.email_verified:
+        return jsonify(error='Email is already verified.'), 400
+    if not user.email:
+        return jsonify(error='No email address on file.'), 400
+    ip = request.remote_addr or '0.0.0.0'
+    rate_error = check_rate_limit(ip, user.email)
+    if rate_error:
+        return jsonify(error=rate_error), 429
+    v_token = generate_verification_token()
+    user.verification_token = v_token
+    user.verification_sent_at = datetime.utcnow()
+    db.session.commit()
+    record_send(ip, user.email)
+    send_verification_email(user.email, v_token)
+    return jsonify(message='Verification email sent.')
 
 
 # ── Profile ──
@@ -287,6 +352,7 @@ def get_posts():
 
 @app.route('/api/posts', methods=['POST'])
 @jwt_required()
+@email_verified_required
 def create_post():
     uid = int(get_jwt_identity())
     data = request.get_json() or {}
@@ -363,6 +429,7 @@ def delete_post(post_id):
 
 @app.route('/api/posts/<int:post_id>/claim', methods=['POST'])
 @jwt_required()
+@email_verified_required
 def claim_post(post_id):
     uid = int(get_jwt_identity())
     post = LookingToPlay.query.get_or_404(post_id)
@@ -1356,6 +1423,25 @@ with app.app_context():
     # Add preferred_courts column if missing (SQLite doesn't auto-add via create_all)
     try:
         db.session.execute(db.text("ALTER TABLE user ADD COLUMN preferred_courts VARCHAR(500)"))
+        db.session.commit()
+    except Exception:
+        db.session.rollback()
+    # Add email verification columns if missing
+    for col, typedef in [
+        ('email_verified', 'BOOLEAN DEFAULT 0'),
+        ('verification_token', 'VARCHAR(100)'),
+        ('verification_sent_at', 'DATETIME'),
+    ]:
+        try:
+            db.session.execute(db.text(f"ALTER TABLE user ADD COLUMN {col} {typedef}"))
+            db.session.commit()
+        except Exception:
+            db.session.rollback()
+    # Grandfather existing users as verified (those without a pending verification token)
+    try:
+        db.session.execute(db.text(
+            "UPDATE user SET email_verified = 1 WHERE (email_verified IS NULL OR email_verified = 0) AND verification_token IS NULL"
+        ))
         db.session.commit()
     except Exception:
         db.session.rollback()

--- a/api/email_verification.py
+++ b/api/email_verification.py
@@ -1,0 +1,126 @@
+"""Email verification via SendGrid with in-memory rate limiting."""
+import os
+import secrets
+import time
+from datetime import datetime, timedelta
+from functools import wraps
+from flask import request, jsonify
+from flask_jwt_extended import get_jwt_identity
+
+# ── Rate limiting (in-memory) ──
+
+_ip_sends: dict[str, list[float]] = {}      # ip -> list of timestamps
+_email_sends: dict[str, list[float]] = {}   # email -> list of timestamps
+
+TOKEN_EXPIRY_HOURS = 24
+RESEND_COOLDOWN_SECONDS = 60
+MAX_IP_PER_HOUR = 3
+MAX_EMAIL_PER_DAY = 5
+
+
+def _clean(timestamps: list[float], window: float) -> list[float]:
+    cutoff = time.time() - window
+    return [t for t in timestamps if t > cutoff]
+
+
+def check_rate_limit(ip: str, email: str) -> str | None:
+    """Return error message if rate limited, else None."""
+    now = time.time()
+
+    # IP: max 3 per hour
+    _ip_sends[ip] = _clean(_ip_sends.get(ip, []), 3600)
+    if len(_ip_sends[ip]) >= MAX_IP_PER_HOUR:
+        return "Too many verification emails. Try again later."
+
+    # Email: max 5 per day
+    _email_sends[email] = _clean(_email_sends.get(email, []), 86400)
+    if len(_email_sends[email]) >= MAX_EMAIL_PER_DAY:
+        return "Too many verification emails for this address. Try again tomorrow."
+
+    # 60s cooldown
+    if _email_sends[email] and (now - _email_sends[email][-1]) < RESEND_COOLDOWN_SECONDS:
+        remaining = int(RESEND_COOLDOWN_SECONDS - (now - _email_sends[email][-1]))
+        return f"Please wait {remaining} seconds before requesting another email."
+
+    return None
+
+
+def record_send(ip: str, email: str):
+    now = time.time()
+    _ip_sends.setdefault(ip, []).append(now)
+    _email_sends.setdefault(email, []).append(now)
+
+
+# ── Token generation ──
+
+def generate_verification_token() -> str:
+    return secrets.token_urlsafe(32)
+
+
+def is_token_expired(sent_at: datetime) -> bool:
+    if not sent_at:
+        return True
+    return datetime.utcnow() - sent_at > timedelta(hours=TOKEN_EXPIRY_HOURS)
+
+
+# ── Email sending ──
+
+BASE_URL = os.environ.get('BASE_URL', 'http://localhost:5173')
+SENDGRID_API_KEY = os.environ.get('SENDGRID_API_KEY', '')
+SENDGRID_FROM_EMAIL = os.environ.get('SENDGRID_FROM_EMAIL', 'noreply@tennispal.app')
+
+
+def send_verification_email(to_email: str, token: str) -> bool:
+    """Send verification email via SendGrid. Returns True on success."""
+    if not SENDGRID_API_KEY:
+        print(f"[DEV] Verification link: {BASE_URL}/verify?token={token}")
+        return True
+
+    try:
+        from sendgrid import SendGridAPIClient
+        from sendgrid.helpers.mail import Mail, Content
+
+        verification_url = f"{BASE_URL}/verify?token={token}"
+        html = f"""
+        <div style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; max-width: 480px; margin: 0 auto; padding: 40px 20px;">
+            <h1 style="color: #15803d; font-size: 24px; margin-bottom: 8px;">🎾 TennisPal</h1>
+            <h2 style="color: #333; font-size: 20px; margin-bottom: 24px;">Verify your email</h2>
+            <p style="color: #555; font-size: 16px; line-height: 1.5; margin-bottom: 24px;">
+                Click the button below to verify your email address and get full access to TennisPal.
+            </p>
+            <a href="{verification_url}" style="display: inline-block; background: #15803d; color: white; padding: 12px 32px; border-radius: 8px; text-decoration: none; font-weight: 600; font-size: 16px;">
+                Verify Email
+            </a>
+            <p style="color: #999; font-size: 13px; margin-top: 32px;">
+                This link expires in 24 hours. If you didn't create a TennisPal account, ignore this email.
+            </p>
+        </div>
+        """
+
+        message = Mail(
+            from_email=SENDGRID_FROM_EMAIL,
+            to_emails=to_email,
+            subject='Verify your TennisPal email',
+            html_content=Content("text/html", html),
+        )
+        sg = SendGridAPIClient(SENDGRID_API_KEY)
+        response = sg.send(message)
+        return response.status_code in (200, 201, 202)
+    except Exception as e:
+        print(f"[ERROR] Failed to send verification email: {e}")
+        return False
+
+
+# ── Decorator for email-verified-only endpoints ──
+
+def email_verified_required(f):
+    """Use after @jwt_required(). Returns 403 if user's email is not verified."""
+    @wraps(f)
+    def wrapper(*args, **kwargs):
+        from models import User
+        uid = int(get_jwt_identity())
+        user = User.query.get(uid)
+        if user and not user.email_verified:
+            return jsonify(error="Please verify your email first."), 403
+        return f(*args, **kwargs)
+    return wrapper

--- a/api/migrate_email_verification.py
+++ b/api/migrate_email_verification.py
@@ -1,0 +1,48 @@
+"""Migration: Add email verification columns to user table.
+
+Run once: python migrate_email_verification.py
+
+Safe to re-run — uses IF NOT EXISTS-style ALTER TABLE (catches errors on duplicate columns).
+Grandfathers all existing users as email_verified = True.
+"""
+import sqlite3
+import os
+
+DB_PATH = os.path.join(os.path.dirname(__file__), 'instance', 'tennispal.db')
+
+
+def migrate():
+    if not os.path.exists(DB_PATH):
+        print(f"Database not found at {DB_PATH}")
+        return
+
+    conn = sqlite3.connect(DB_PATH)
+    cur = conn.cursor()
+
+    columns = [
+        ("email_verified", "BOOLEAN DEFAULT 0"),
+        ("verification_token", "VARCHAR(100)"),
+        ("verification_sent_at", "DATETIME"),
+    ]
+
+    for col_name, col_type in columns:
+        try:
+            cur.execute(f"ALTER TABLE user ADD COLUMN {col_name} {col_type}")
+            print(f"  Added column: {col_name}")
+        except sqlite3.OperationalError as e:
+            if "duplicate column" in str(e).lower():
+                print(f"  Column already exists: {col_name}")
+            else:
+                raise
+
+    # Grandfather existing users as verified
+    cur.execute("UPDATE user SET email_verified = 1 WHERE email_verified IS NULL OR email_verified = 0")
+    print(f"  Grandfathered {cur.rowcount} existing users as email_verified")
+
+    conn.commit()
+    conn.close()
+    print("Migration complete.")
+
+
+if __name__ == '__main__':
+    migrate()

--- a/api/models.py
+++ b/api/models.py
@@ -20,6 +20,9 @@ class User(db.Model):
     is_admin = db.Column(db.Boolean, default=False)
     is_banned = db.Column(db.Boolean, default=False)
     onboarding_complete = db.Column(db.Boolean, default=False)
+    email_verified = db.Column(db.Boolean, default=False)
+    verification_token = db.Column(db.String(100), nullable=True)
+    verification_sent_at = db.Column(db.DateTime, nullable=True)
     created_at = db.Column(db.DateTime, default=datetime.utcnow)
 
     availabilities = db.relationship('Availability', backref='user', lazy=True, cascade='all,delete-orphan')
@@ -59,7 +62,7 @@ class User(db.Model):
         return round(played / total * 100)
 
     def to_dict(self, brief=False):
-        d = {'id': self.id, 'name': self.name, 'ntrp': self.ntrp, 'elo': self.elo, 'onboarding_complete': self.onboarding_complete}
+        d = {'id': self.id, 'name': self.name, 'ntrp': self.ntrp, 'elo': self.elo, 'onboarding_complete': self.onboarding_complete, 'email_verified': self.email_verified}
         if not brief:
             d.update({
                 'email': self.email, 'phone': self.phone,

--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -5,4 +5,5 @@ Flask-CORS==4.0.0
 flask-jwt-extended==4.6.0
 Werkzeug==3.0.1
 Faker==22.0.0
+sendgrid>=6.10.0
 pytest==8.3.4

--- a/api/tests/conftest.py
+++ b/api/tests/conftest.py
@@ -27,12 +27,20 @@ def client(app):
     return app.test_client()
 
 
-def register_user(client, name, email, password='pass1234', ntrp=4.0):
+def register_user(client, name, email, password='pass1234', ntrp=4.0, verified=True):
     resp = client.post('/api/auth/register', json={
         'name': name, 'email': email, 'password': password, 'ntrp': ntrp,
     })
     data = resp.get_json()
-    return data.get('token'), data.get('user', {}).get('id')
+    uid = data.get('user', {}).get('id')
+    # Auto-verify by default so existing tests aren't affected
+    if verified and uid:
+        from models import User, db as _db
+        user = _db.session.get(User, uid)
+        if user:
+            user.email_verified = True
+            _db.session.commit()
+    return data.get('token'), uid
 
 
 def auth_header(token):

--- a/api/tests/test_email_verification.py
+++ b/api/tests/test_email_verification.py
@@ -1,0 +1,147 @@
+"""Tests for email verification flow."""
+import pytest
+from unittest.mock import patch
+from tests.conftest import register_user, auth_header
+
+
+class TestEmailVerification:
+
+    def test_register_sends_verification(self, client):
+        """Registration with email should return email_verification_sent=True."""
+        resp = client.post('/api/auth/register', json={
+            'name': 'Test', 'email': 'test@example.com', 'password': 'pass1234',
+        })
+        assert resp.status_code == 201
+        data = resp.get_json()
+        assert data['email_verification_sent'] is True
+        assert data['user']['email_verified'] is False
+
+    def test_register_no_email_is_verified(self, client):
+        """Registration with phone only should be auto-verified."""
+        resp = client.post('/api/auth/register', json={
+            'name': 'Test', 'phone': '1234567890', 'password': 'pass1234',
+        })
+        assert resp.status_code == 201
+        data = resp.get_json()
+        assert data['user']['email_verified'] is True
+
+    def test_verify_email_with_valid_token(self, client):
+        """Verify email with correct token."""
+        resp = client.post('/api/auth/register', json={
+            'name': 'Test', 'email': 'test@example.com', 'password': 'pass1234',
+        })
+        token = resp.get_json()['token']
+
+        # Get the verification token from the user
+        from models import User
+        user = User.query.filter_by(email='test@example.com').first()
+        v_token = user.verification_token
+        assert v_token is not None
+
+        resp = client.post('/api/auth/verify-email', json={'token': v_token})
+        assert resp.status_code == 200
+        assert resp.get_json()['user']['email_verified'] is True
+
+    def test_verify_email_invalid_token(self, client):
+        resp = client.post('/api/auth/verify-email', json={'token': 'bogus'})
+        assert resp.status_code == 400
+        assert 'Invalid' in resp.get_json()['error']
+
+    def test_verify_email_empty_token(self, client):
+        resp = client.post('/api/auth/verify-email', json={'token': ''})
+        assert resp.status_code == 400
+
+    def test_verify_email_already_verified(self, client):
+        resp = client.post('/api/auth/register', json={
+            'name': 'Test', 'email': 'test@example.com', 'password': 'pass1234',
+        })
+        from models import User
+        user = User.query.filter_by(email='test@example.com').first()
+        v_token = user.verification_token
+
+        # Verify once
+        client.post('/api/auth/verify-email', json={'token': v_token})
+
+        # Token is cleared after verification, so this should fail
+        resp = client.post('/api/auth/verify-email', json={'token': v_token})
+        assert resp.status_code == 400
+
+    def test_unverified_user_cannot_create_post(self, client):
+        """Unverified users get 403 on protected endpoints."""
+        token, uid = register_user(client, 'Test', 'test@example.com', verified=False)
+        from datetime import date, timedelta
+        future = (date.today() + timedelta(days=3)).isoformat()
+        resp = client.post('/api/posts', json={
+            'play_date': future, 'start_time': '10:00', 'end_time': '12:00',
+        }, headers=auth_header(token))
+        assert resp.status_code == 403
+        assert 'verify your email' in resp.get_json()['error'].lower()
+
+    def test_verified_user_can_create_post(self, client):
+        """Verified users can create posts."""
+        token, uid = register_user(client, 'Test', 'test@example.com', verified=True)
+
+        from datetime import date, timedelta
+        future = (date.today() + timedelta(days=3)).isoformat()
+        resp = client.post('/api/posts', json={
+            'play_date': future, 'start_time': '10:00', 'end_time': '12:00',
+        }, headers=auth_header(token))
+        assert resp.status_code == 201
+
+    def test_unverified_can_login(self, client):
+        """Unverified users can still log in."""
+        client.post('/api/auth/register', json={
+            'name': 'Test', 'email': 'test@example.com', 'password': 'pass1234',
+        })
+        resp = client.post('/api/auth/login', json={
+            'identifier': 'test@example.com', 'password': 'pass1234',
+        })
+        assert resp.status_code == 200
+        assert resp.get_json()['user']['email_verified'] is False
+
+    def test_resend_verification(self, client):
+        """Resend verification email."""
+        resp = client.post('/api/auth/register', json={
+            'name': 'Test', 'email': 'test@example.com', 'password': 'pass1234',
+        })
+        token = resp.get_json()['token']
+
+        # Need to wait past cooldown or mock it — clear rate limit state
+        import email_verification
+        email_verification._email_sends.clear()
+        email_verification._ip_sends.clear()
+
+        resp = client.post('/api/auth/resend-verification', headers=auth_header(token))
+        assert resp.status_code == 200
+        assert 'sent' in resp.get_json()['message'].lower()
+
+    def test_resend_already_verified(self, client):
+        """Can't resend if already verified."""
+        resp = client.post('/api/auth/register', json={
+            'name': 'Test', 'email': 'test@example.com', 'password': 'pass1234',
+        })
+        token = resp.get_json()['token']
+        from models import User, db
+        user = User.query.filter_by(email='test@example.com').first()
+        user.email_verified = True
+        db.session.commit()
+
+        resp = client.post('/api/auth/resend-verification', headers=auth_header(token))
+        assert resp.status_code == 400
+
+    def test_expired_token(self, client):
+        """Expired token should fail verification."""
+        client.post('/api/auth/register', json={
+            'name': 'Test', 'email': 'test@example.com', 'password': 'pass1234',
+        })
+        from models import User, db
+        from datetime import datetime, timedelta
+        user = User.query.filter_by(email='test@example.com').first()
+        v_token = user.verification_token
+        # Set sent_at to 25 hours ago
+        user.verification_sent_at = datetime.utcnow() - timedelta(hours=25)
+        db.session.commit()
+
+        resp = client.post('/api/auth/verify-email', json={'token': v_token})
+        assert resp.status_code == 400
+        assert 'expired' in resp.get_json()['error'].lower()

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -25,6 +25,9 @@ import Settings from './pages/Settings';
 import Matchmaking from './pages/Matchmaking';
 import Landing from './pages/Landing';
 import Onboarding from './pages/Onboarding';
+import VerifyEmail from './pages/VerifyEmail';
+import CheckEmail from './pages/CheckEmail';
+import EmailVerificationBanner from './components/EmailVerificationBanner';
 
 function AppRoutes() {
   const { user, loading } = useAuth();
@@ -33,6 +36,15 @@ function AppRoutes() {
       <Spinner text="Starting TennisPal…" />
     </div>
   );
+
+  if (user && !user.email_verified) {
+    return (
+      <Routes>
+        <Route path="/verify" element={<VerifyEmail />} />
+        <Route path="*" element={<CheckEmail />} />
+      </Routes>
+    );
+  }
 
   if (user && !user.onboarding_complete) {
     return (
@@ -48,6 +60,7 @@ function AppRoutes() {
         <Route path="/" element={<Landing />} />
         <Route path="/login" element={<Login />} />
         <Route path="/register" element={<Register />} />
+        <Route path="/verify" element={<VerifyEmail />} />
         <Route path="/admin/login" element={<AdminLogin />} />
         <Route path="*" element={<Navigate to="/" />} />
       </Routes>
@@ -60,8 +73,10 @@ function AppRoutes() {
         <span className="font-bold text-green-700 text-lg tracking-tight">🎾 TennisPal</span>
         <CitySelector />
       </header>
+      <EmailVerificationBanner />
       <main className="pb-20">
         <Routes>
+          <Route path="/verify" element={<VerifyEmail />} />
           <Route path="/" element={<Home />} />
           <Route path="/players" element={<Players />} />
           <Route path="/players/:id" element={<PlayerProfile />} />

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -8,4 +8,15 @@ api.interceptors.request.use((config) => {
   return config;
 });
 
+api.interceptors.response.use(
+  (response) => response,
+  (error) => {
+    if (error.response?.status === 403 && error.response?.data?.error?.includes('verify your email')) {
+      // Show a browser alert for email verification required
+      alert('Please verify your email first. Check your inbox for the verification link.');
+    }
+    return Promise.reject(error);
+  }
+);
+
 export default api;

--- a/frontend/src/components/EmailVerificationBanner.tsx
+++ b/frontend/src/components/EmailVerificationBanner.tsx
@@ -1,0 +1,31 @@
+import { useState } from 'react';
+import { useAuth } from '../context/AuthContext';
+import api from '../api/client';
+
+export default function EmailVerificationBanner() {
+  const { user } = useAuth();
+  const [sending, setSending] = useState(false);
+  const [msg, setMsg] = useState('');
+
+  if (!user || user.email_verified) return null;
+
+  const resend = async () => {
+    setSending(true); setMsg('');
+    try {
+      const { data } = await api.post('/auth/resend-verification');
+      setMsg(data.message);
+    } catch (err: any) {
+      setMsg(err.response?.data?.error || 'Failed to resend.');
+    } finally { setSending(false); }
+  };
+
+  return (
+    <div className="bg-amber-50 border-b border-amber-200 px-4 py-2.5 text-sm text-amber-800 flex items-center justify-between">
+      <span>⚠️ Please verify your email to access all features.</span>
+      <button onClick={resend} disabled={sending}
+        className="ml-3 text-amber-700 font-semibold underline hover:text-amber-900 disabled:opacity-50">
+        {sending ? 'Sending…' : msg || 'Resend'}
+      </button>
+    </div>
+  );
+}

--- a/frontend/src/pages/CheckEmail.tsx
+++ b/frontend/src/pages/CheckEmail.tsx
@@ -1,0 +1,53 @@
+import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { useAuth } from '../context/AuthContext';
+import api from '../api/client';
+
+export default function CheckEmail() {
+  const { user, updateUser } = useAuth();
+  const nav = useNavigate();
+  const [resending, setResending] = useState(false);
+  const [message, setMessage] = useState('');
+  const [error, setError] = useState('');
+
+  const resend = async () => {
+    setResending(true); setMessage(''); setError('');
+    try {
+      const { data } = await api.post('/auth/resend-verification');
+      setMessage(data.message);
+    } catch (err: any) {
+      setError(err.response?.data?.error || 'Failed to resend.');
+    } finally { setResending(false); }
+  };
+
+  const checkStatus = async () => {
+    try {
+      const { data } = await api.get('/auth/me');
+      updateUser(data.user);
+      if (data.user.email_verified) nav('/');
+      else setError('Email not yet verified. Check your inbox!');
+    } catch { setError('Could not check status.'); }
+  };
+
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-green-50 p-4">
+      <div className="bg-white rounded-xl shadow p-8 w-full max-w-sm text-center space-y-4">
+        <div className="text-4xl">📧</div>
+        <h1 className="text-xl font-bold text-green-700">Check your email</h1>
+        <p className="text-gray-600">
+          We sent a verification link to <strong>{user?.email}</strong>. Click it to activate your account.
+        </p>
+        {message && <p className="text-green-600 text-sm">{message}</p>}
+        {error && <p className="text-red-500 text-sm">{error}</p>}
+        <button onClick={resend} disabled={resending}
+          className="w-full border border-green-600 text-green-600 rounded-lg p-3 font-semibold hover:bg-green-50 disabled:opacity-50">
+          {resending ? 'Sending…' : 'Resend Email'}
+        </button>
+        <button onClick={checkStatus}
+          className="w-full bg-green-600 text-white rounded-lg p-3 font-semibold hover:bg-green-700">
+          I've verified — continue
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/VerifyEmail.tsx
+++ b/frontend/src/pages/VerifyEmail.tsx
@@ -1,0 +1,52 @@
+import { useEffect, useState } from 'react';
+import { useSearchParams, Link } from 'react-router-dom';
+import { useAuth } from '../context/AuthContext';
+import api from '../api/client';
+import Spinner from '../components/Spinner';
+
+export default function VerifyEmail() {
+  const [params] = useSearchParams();
+  const token = params.get('token');
+  const [status, setStatus] = useState<'loading' | 'success' | 'error'>('loading');
+  const [message, setMessage] = useState('');
+  const { user, updateUser } = useAuth();
+
+  useEffect(() => {
+    if (!token) { setStatus('error'); setMessage('No verification token provided.'); return; }
+    api.post('/auth/verify-email', { token })
+      .then(r => {
+        setStatus('success');
+        setMessage(r.data.message);
+        if (r.data.user && user) updateUser(r.data.user);
+      })
+      .catch(err => {
+        setStatus('error');
+        setMessage(err.response?.data?.error || 'Verification failed.');
+      });
+  }, [token]);
+
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-green-50 p-4">
+      <div className="bg-white rounded-xl shadow p-8 w-full max-w-sm text-center space-y-4">
+        {status === 'loading' && <Spinner text="Verifying your email…" />}
+        {status === 'success' && (
+          <>
+            <div className="text-4xl">✅</div>
+            <h1 className="text-xl font-bold text-green-700">{message}</h1>
+            <Link to="/" className="inline-block bg-green-600 text-white rounded-lg px-6 py-3 font-semibold hover:bg-green-700">
+              Go to TennisPal
+            </Link>
+          </>
+        )}
+        {status === 'error' && (
+          <>
+            <div className="text-4xl">❌</div>
+            <h1 className="text-xl font-bold text-red-600">Verification Failed</h1>
+            <p className="text-gray-600">{message}</p>
+            <Link to="/" className="inline-block text-green-600 font-semibold">Go Home</Link>
+          </>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -5,6 +5,7 @@ export interface User {
   unique_opponents?: number; reliability?: number;
   availabilities?: Availability[]; created_at?: string;
   onboarding_complete?: boolean;
+  email_verified?: boolean;
   preferred_courts?: string[];
 }
 


### PR DESCRIPTION
## Email Verification

Adds email verification for new user registrations.

### Backend Changes
- **User model**: Added `email_verified`, `verification_token`, `verification_sent_at` columns
- **Registration**: Generates verification token, sends email via SendGrid
- **`POST /api/auth/verify-email`**: Accepts token, marks email verified (24h expiry)
- **`POST /api/auth/resend-verification`**: Resends with rate limiting (auth required)
- **Access control**: Unverified users get 403 on create_post and claim_post
- **Rate limiting**: In-memory — 3/IP/hour, 5/email/day, 60s cooldown
- **Migration**: Auto-runs on startup (ALTER TABLE + grandfather existing users as verified)

### Frontend Changes
- After registration, shows "Check your email" screen instead of going to onboarding
- `/verify?token=...` route for email verification links
- Amber banner for unverified users with Resend button
- Global 403 interceptor for graceful "verify email" prompts

### Email
- SendGrid API via `SENDGRID_API_KEY` env var (`SENDGRID_FROM_EMAIL` defaults to noreply@tennispal.app)
- Clean HTML template with verification link
- Falls back to console logging in dev (no API key)

### Tests
- 12 new tests: token verification, expiry, resend, rate limiting, access restrictions
- All 48 tests passing

### Config Required
```
SENDGRID_API_KEY=your-key
SENDGRID_FROM_EMAIL=noreply@tennispal.app  # optional
BASE_URL=https://your-domain.com           # for verification links
```