### PR TITLE
feat: Add pre-filled SMS buttons for match coordination

### DIFF
--- a/api/app.py
+++ b/api/app.py
@@ -670,7 +670,7 @@ def get_match(match_id):
     data = match.to_dict()
     # Include contact info only for confirmed match participants
     is_participant = uid in (match.player1_id, match.player2_id)
-    if is_participant and match.status == 'completed' and match.score_confirmed:
+    if is_participant and match.status in ('scheduled', 'completed'):
         opponent = match.player2 if match.player1_id == uid else match.player1
         data['opponent_contact'] = {
             'email': opponent.email,

--- a/frontend/src/pages/MatchDetail.tsx
+++ b/frontend/src/pages/MatchDetail.tsx
@@ -8,6 +8,7 @@ import ReviewModal from '../components/ReviewModal';
 import { Spinner, ErrorBox } from '../components/ui';
 import { SetScore } from '../types';
 import { useReviewStatus } from '../hooks/useReviews';
+import { buildSmsUri } from '../utils/sms';
 
 export default function MatchDetail() {
   const { id } = useParams();
@@ -72,10 +73,22 @@ export default function MatchDetail() {
           <h2 className="font-semibold text-gray-700 mb-3">📇 Contact Info</h2>
           <div className="space-y-2">
             {match.opponent_contact.phone && (
-              <a href={`tel:${match.opponent_contact.phone}`} className="flex items-center gap-3 p-3 bg-green-50 rounded-lg text-green-700 font-medium active:bg-green-100 transition-colors">
-                <span className="text-lg">📱</span>
-                <span>{match.opponent_contact.phone}</span>
-              </a>
+              <>
+                <a href={`tel:${match.opponent_contact.phone}`} className="flex items-center gap-3 p-3 bg-green-50 rounded-lg text-green-700 font-medium active:bg-green-100 transition-colors">
+                  <span className="text-lg">📱</span>
+                  <span>{match.opponent_contact.phone}</span>
+                </a>
+                {(() => {
+                  const opponentName = user?.id === match.player1.id ? match.player2.name : match.player1.name;
+                  const body = `Hey ${opponentName}! Ready for our tennis match on ${match.play_date}. See you there! 🎾`;
+                  return (
+                    <a href={buildSmsUri(match.opponent_contact.phone!, body)}
+                      className="flex items-center justify-center gap-2 p-3 bg-green-600 text-white rounded-lg font-semibold active:bg-green-800 transition-colors">
+                      <span>📱</span> Text Opponent
+                    </a>
+                  );
+                })()}
+              </>
             )}
             {match.opponent_contact.email && (
               <a href={`mailto:${match.opponent_contact.email}`} className="flex items-center gap-3 p-3 bg-blue-50 rounded-lg text-blue-700 font-medium active:bg-blue-100 transition-colors">

--- a/frontend/src/pages/Matches.tsx
+++ b/frontend/src/pages/Matches.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { Link } from 'react-router-dom';
+import { Link, useNavigate } from 'react-router-dom';
 import { useMatches, useRecentResults, useRespondInvite } from '../hooks/useMatches';
 import { useAuth } from '../context/AuthContext';
 import { useToast } from '../components/Toast';
@@ -12,12 +12,20 @@ export default function Matches() {
   const { data: recentResults, isLoading: recentLoading } = useRecentResults();
   const respondMutation = useRespondInvite();
   const { toast } = useToast();
+  const navigate = useNavigate();
   const hasPending = (myData?.pending_invites?.length ?? 0) > 0;
   const [showInvites, setShowInvites] = useState(hasPending);
 
   const handleRespond = (id: number, action: 'accept' | 'decline') => {
     respondMutation.mutate({ id, action }, {
-      onSuccess: () => toast(action === 'accept' ? 'Invite accepted! Match on 🎾' : 'Invite declined'),
+      onSuccess: (data) => {
+        if (action === 'accept' && data?.data?.match?.id) {
+          toast('Invite accepted! Match on 🎾');
+          navigate(`/matches/${data.data.match.id}`);
+        } else {
+          toast(action === 'accept' ? 'Invite accepted! Match on 🎾' : 'Invite declined');
+        }
+      },
       onError: () => toast('Failed to respond to invite', 'error'),
     });
   };

--- a/frontend/src/pages/PlayerProfile.tsx
+++ b/frontend/src/pages/PlayerProfile.tsx
@@ -5,6 +5,7 @@ import { useAuth } from '../context/AuthContext';
 import { Spinner, ErrorBox } from '../components/ui';
 import ProfileTags from '../components/ProfileTags';
 import PlayerBadges from '../components/PlayerBadges';
+import { buildSmsUri } from '../utils/sms';
 
 const DAYS = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun'];
 const HOURS = Array.from({ length: 17 }, (_, i) => i + 6);
@@ -36,7 +37,15 @@ export default function PlayerProfile() {
           <div className="bg-yellow-50 rounded-lg p-2"><div className="text-lg font-bold text-yellow-600">{player.reliability}%</div><div className="text-xs text-gray-500">Reliable</div></div>
         </div>
         {me && me.id !== player.id && (
-          <Link to={`/invite/${player.id}`} className="block mt-4 bg-green-600 text-white text-center rounded-lg py-3 font-semibold hover:bg-green-700 active:bg-green-800 transition-colors">Invite to Play 🎾</Link>
+          <>
+            <Link to={`/invite/${player.id}`} className="block mt-4 bg-green-600 text-white text-center rounded-lg py-3 font-semibold hover:bg-green-700 active:bg-green-800 transition-colors">Invite to Play 🎾</Link>
+            {player.phone && (
+              <a href={buildSmsUri(player.phone, `Hey ${player.name}, found you on TennisPal! Want to hit sometime? 🎾`)}
+                className="block mt-2 bg-green-100 text-green-700 text-center rounded-lg py-3 font-semibold hover:bg-green-200 active:bg-green-300 transition-colors">
+                📱 Text Player
+              </a>
+            )}
+          </>
         )}
       </div>
 

--- a/frontend/src/utils/sms.ts
+++ b/frontend/src/utils/sms.ts
@@ -1,0 +1,7 @@
+/**
+ * Build an SMS URI that works on both iOS and Android.
+ * Uses `sms:NUMBER?&body=MESSAGE` which is compatible with both platforms.
+ */
+export function buildSmsUri(phone: string, body: string): string {
+  return `sms:${encodeURIComponent(phone)}?&body=${encodeURIComponent(body)}`;
+}


### PR DESCRIPTION
## Summary
Adds SMS coordination buttons so players can quickly text each other with pre-filled messages.

### Changes

**MatchDetail page** — Green "📱 Text Opponent" button in the contact section that:
- Opens native SMS app with pre-filled message including match date and opponent name
- Only shows when opponent has a phone number on file

**PlayerProfile page** — "📱 Text Player" button below the Invite button:
- Pre-fills a friendly intro message
- Only shows when the player has a phone number

**Matches page** — After accepting an invite, navigates to the match detail page where the SMS button is immediately available for coordination.

**Backend** — Expanded `opponent_contact` to also be returned for `scheduled` matches (previously only `completed` + confirmed), so players can coordinate before playing.

**SMS URI** — Uses `sms:NUMBER?&body=MESSAGE` format compatible with both iOS and Android.

### No deployment needed